### PR TITLE
Add argument to hide submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ plugins:
         <module_name>:
           section: <docs_section> 
           source_repo: <URL_of_source>
+          hidden: ["submodules", "to", "omit"]
 ```
 
 The plugin will find, and document all submodules, classes, attributes, functions etc. and, if you're using `mkdocs serve`, changes to the documentation will be reflected live.

--- a/mktheapidocs/plugin.py
+++ b/mktheapidocs/plugin.py
@@ -79,7 +79,7 @@ class Plugin(mkdocs.plugins.BasePlugin):
             importlib.reload(module)
             src_path = pathlib.Path(module.__file__).parent.parent.absolute()
             target_path = pathlib.Path(config["site_dir"])
-            for module, file in get_submodule_files(module):
+            for module, file in get_submodule_files(module, details["hidden"]):
                 importlib.reload(module)
                 do_doc = functools.partial(
                     doc_module,


### PR DESCRIPTION
This PR allows the user to pass a list of submodules to hide in the generated API reference. In `mkdocs.yaml`, the user can supply:

```python
hidden: ["submodules", "to", "omit"]
```