### PR TITLE
Correct path to files on github

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,5 @@ plugins:
 The plugin will find, and document all submodules, classes, attributes, functions etc. and, if you're using `mkdocs serve`, changes to the documentation will be reflected live.
 
 If you want to manually configure your nav, then you can specify where the api documentation section will be using an `api-docs-<docs_section>` placeholder.
+
+The documentation will contain links combining the `source_repo` with the path to source files relative to the package directory.  For example, if the repo is hosted on github, `source_repo` should include `blob` and the branch name, as in `https://github.com/greenape/mktheapidocs/blob/master`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,7 +6,7 @@ plugins:
       modules: 
         mktheapidocs:
           section: api 
-          source_repo: "https://github.com/greenape/mktheapidocs"
+          source_repo: "https://github.com/greenape/mktheapidocs/blob/master"
 
 theme:
   name: 'material'


### PR DESCRIPTION
The `source_repo` variable should link to the blob and branch, or there will be broken links in the generated documentation.