### PR TITLE
Fix attribute error, generating docs, etc.

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,23 +10,23 @@ plugins:
 
 theme:
   name: 'material'
+  icon:
+    repo: fontawesome/brands/github
   # Don't include MkDocs' JavaScript
   include_search_page: false
   search_index_only: true
 
   # Default values, taken from mkdocs_theme.yml
   language: en
-  feature:
-      tabs: true
+  features:
+    - navigation.tabs
   palette:
       primary: "green"
       accent: "green"
   font:
       text: Roboto
       code: Roboto Mono
-  favicon: assets/images/favicon.png
-  logo:
-      icon: "\uE80C"
+
 # Extensions
 markdown_extensions:
   - markdown.extensions.admonition
@@ -57,7 +57,6 @@ markdown_extensions:
 
 
 extra:
-  repo_icon: 'github'
   social:
-    - type: 'github'
+    - icon: fontawesome/brands/github
       link: 'https://github.com/greenape/mktheapidocs'

--- a/mktheapidocs/plugin.py
+++ b/mktheapidocs/plugin.py
@@ -130,9 +130,8 @@ class Plugin(mkdocs.plugins.BasePlugin):
     #    root_path = pathlib.Path(config['docs_dir'])
     #    self.files = list(chain(*[make_api_doc(module_name, root_path / target, source_location) for module_name, target, source_location in self.config['modules']]))
 
-    def on_serve(self, server, config, **kwargs):
+    def on_serve(self, server, config, builder, **kwargs):
         # print(server.__dict__)
         # print(config)
-        builder = server.watcher._tasks[config["docs_dir"]]["func"]
         for file, func in self.files.values():
             server.watch(str(file.abs_src_path), builder)

--- a/mktheapidocs/plugin.py
+++ b/mktheapidocs/plugin.py
@@ -64,7 +64,7 @@ def find_section_anchor(nav, anchor):
 
 
 class Plugin(mkdocs.plugins.BasePlugin):
-    config_scheme = (("modules", Module()),)
+    config_scheme = (("modules", Module(required=True)),)
 
     def on_config(self, config):
         # print(config)

--- a/mktheapidocs/plugin.py
+++ b/mktheapidocs/plugin.py
@@ -44,6 +44,10 @@ class Module(mkdocs.config.config_options.OptionallyRequired):
             raise mkdocs.config.config_options.ValidationError(
                 f"{module} not found. Have you installed it?"
             )
+        except AttributeError:
+            raise mkdocs.config.config_options.ValidationError(
+                f"expected <class 'dict'>, but got {type(value)}"
+            )
         return value
 
 

--- a/mktheapidocs/plugin.py
+++ b/mktheapidocs/plugin.py
@@ -79,7 +79,7 @@ class Plugin(mkdocs.plugins.BasePlugin):
             importlib.reload(module)
             src_path = pathlib.Path(module.__file__).parent.parent.absolute()
             target_path = pathlib.Path(config["site_dir"])
-            for module, file in get_submodule_files(module, details["hidden"]):
+            for module, file in get_submodule_files(module, details.get("hidden", [])):
                 importlib.reload(module)
                 do_doc = functools.partial(
                     doc_module,


### PR DESCRIPTION
This PR fixes a few bugs that have appeared due to changes with the mkdocs and mkdocs-material packages. The two most important commits in this PR are e277de74b45d013dd39de8ff8472c9fb875362f3 and ff4972788de1cda248a911607c8732fa7925c9c6.

 - e277de74b45d013dd39de8ff8472c9fb875362f3 fixes an issue where `builder = server.watcher [...]` causes an attribute error because `server` doesn't have an attribute called `watcher`. The `builder` variable is provided to `on_serve` as of mkdocs v1.1.1, so the fix switches to using that.
 - ff4972788de1cda248a911607c8732fa7925c9c6 incorporates all of the API changes described in mkdocs-material's [How to upgrade](https://squidfunk.github.io/mkdocs-material/upgrade/) guide. This fixes an 'unhashable type' error and allows generation of the docs in this repo.
 - The remaining three commits in this PR make mktheapidocs configuration nicer with better error messages and optional configuration.