### PR TITLE
Fixed formatting errors for CI

### DIFF
--- a/mktheapidocs/mkapi.py
+++ b/mktheapidocs/mkapi.py
@@ -1,4 +1,11 @@
-import inspect, os, pathlib, importlib, black, re, click, enum
+import inspect
+import os
+import pathlib
+import importlib
+import black
+import re
+import click
+import enum
 from numpydoc.docscrape import NumpyDocString, FunctionDoc, ClassDoc
 from functools import cmp_to_key
 
@@ -51,7 +58,8 @@ def get_submodule_files(module, hide=["_version"]):
             try:
                 for file in files:
                     module_name = (
-                        "" if "__init__.py" == file else inspect.getmodulename(file)
+                        "" if "__init__.py" == file else inspect.getmodulename(
+                            file)
                     )
                     if module_name is not None and module_name not in hide:
                         submodule = importlib.import_module(
@@ -59,7 +67,8 @@ def get_submodule_files(module, hide=["_version"]):
                         )
                         modules.add((submodule, module_path / file))
             except ModuleNotFoundError:
-                print(f"Skipping {'.'.join(module_path.parts)} - not a module.")
+                print(
+                    f"Skipping {'.'.join(module_path.parts)} - not a module.")
     return _sort_modules(modules)
 
 
@@ -95,7 +104,8 @@ def get_all_modules_from_files(module, hide=["__init__", "_version"]):
                                     )
                                 )
             except ModuleNotFoundError:
-                print(f"Skipping {'.'.join(module_path.parts)} - not a module.")
+                print(
+                    f"Skipping {'.'.join(module_path.parts)} - not a module.")
     os.chdir(dir_was)
     return modules
 
@@ -489,7 +499,7 @@ def get_source_link(thing, source_location):
 def get_signature(name, thing):
     """
     Get the signature for a function or class, formatted nicely if possible.
-    
+
     Parameters
     ----------
     name : str
@@ -802,7 +812,8 @@ def doc_module(module_name, module, output_dir, source_location, leaf):
             for x in inspect.getmembers(cls, inspect.isfunction)
             if (not x[0].startswith("_")) and deffed_here(x[1], cls)
         ]
-        class_methods += inspect.getmembers(cls, lambda o: isinstance(o, property))
+        class_methods += inspect.getmembers(cls,
+                                            lambda o: isinstance(o, property))
         if len(class_methods) > 0:
             doc.append("## Methods \n\n")
             for method_name, method in class_methods:

--- a/mktheapidocs/mkapi.py
+++ b/mktheapidocs/mkapi.py
@@ -33,7 +33,7 @@ def get_line(thing):
 
 
 def _sort_modules(mods):
-    """ Always sort `index` or `README` as first filename in list. """
+    """Always sort `index` or `README` as first filename in list."""
 
     def compare(x, y):
         x = x[1]
@@ -58,8 +58,7 @@ def get_submodule_files(module, hide=["_version"]):
             try:
                 for file in files:
                     module_name = (
-                        "" if "__init__.py" == file else inspect.getmodulename(
-                            file)
+                        "" if "__init__.py" == file else inspect.getmodulename(file)
                     )
                     if module_name is not None and module_name not in hide:
                         submodule = importlib.import_module(
@@ -67,8 +66,7 @@ def get_submodule_files(module, hide=["_version"]):
                         )
                         modules.add((submodule, module_path / file))
             except ModuleNotFoundError:
-                print(
-                    f"Skipping {'.'.join(module_path.parts)} - not a module.")
+                print(f"Skipping {'.'.join(module_path.parts)} - not a module.")
     return _sort_modules(modules)
 
 
@@ -104,8 +102,7 @@ def get_all_modules_from_files(module, hide=["__init__", "_version"]):
                                     )
                                 )
             except ModuleNotFoundError:
-                print(
-                    f"Skipping {'.'.join(module_path.parts)} - not a module.")
+                print(f"Skipping {'.'.join(module_path.parts)} - not a module.")
     os.chdir(dir_was)
     return modules
 
@@ -812,8 +809,7 @@ def doc_module(module_name, module, output_dir, source_location, leaf):
             for x in inspect.getmembers(cls, inspect.isfunction)
             if (not x[0].startswith("_")) and deffed_here(x[1], cls)
         ]
-        class_methods += inspect.getmembers(cls,
-                                            lambda o: isinstance(o, property))
+        class_methods += inspect.getmembers(cls, lambda o: isinstance(o, property))
         if len(class_methods) > 0:
             doc.append("## Methods \n\n")
             for method_name, method in class_methods:

--- a/mktheapidocs/plugin.py
+++ b/mktheapidocs/plugin.py
@@ -106,7 +106,8 @@ class Plugin(mkdocs.plugins.BasePlugin):
                 self.module_files[target].append(f)
             if config["nav"]:
                 try:
-                    ix, nav = find_section_anchor(config["nav"], f"api-docs-{target}")
+                    ix, nav = find_section_anchor(
+                        config["nav"], f"api-docs-{target}")
                     nav[ix] = nest_paths(f.src_path for f in self.module_files[target])[
                         0
                     ]

--- a/mktheapidocs/plugin.py
+++ b/mktheapidocs/plugin.py
@@ -19,14 +19,14 @@ class PyDocFile(mkdocs.structure.files.File):
         return True
 
     def _get_stem(self):
-        """ Return the name of the file without it's extension. """
+        """Return the name of the file without it's extension."""
         filename = os.path.basename(self.src_path)
         stem, ext = os.path.splitext(filename)
         return "index" if stem in ("index", "README", "__init__") else stem
 
 
 class Module(mkdocs.config.config_options.OptionallyRequired):
-    """ Validate modules specified are installed. """
+    """Validate modules specified are installed."""
 
     def run_validation(self, value):
         try:
@@ -106,8 +106,7 @@ class Plugin(mkdocs.plugins.BasePlugin):
                 self.module_files[target].append(f)
             if config["nav"]:
                 try:
-                    ix, nav = find_section_anchor(
-                        config["nav"], f"api-docs-{target}")
+                    ix, nav = find_section_anchor(config["nav"], f"api-docs-{target}")
                     nav[ix] = nest_paths(f.src_path for f in self.module_files[target])[
                         0
                     ]


### PR DESCRIPTION
Noticed the latest commit (cefaf47cfbd91c11e65001eaa6b44fdbc36bba48) had a failed pipeline due to formatting errors: https://app.circleci.com/pipelines/github/greenape/mktheapidocs/46/workflows/b091079b-ee57-473b-b817-9810e8594373/jobs/101

I hope this fixes that (won't know until CI pipeline runs against it).